### PR TITLE
Update image to RHEL 10.2 (rhel-10-2-eus-06-08-26)

### DIFF
--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -1,7 +1,7 @@
 ---
 virtualmachines:
   - name: "rhel"
-    image: "rhel-10-0-07-09-25-3"
+    image: "rhel-10-2-eus-06-08-26"
     bootloader: efi
     memory: "4G"
     cores: 1

--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -7,8 +7,8 @@ virtualmachines:
     cores: 1
     image_size: "40G"
     register_satellite: false
-    packages:
-      - stress-ng
+    # packages:
+    # - stress-ng
     tags:
       - key: "AnsibleGroup"
         value: "bastions"

--- a/config/instances.yaml
+++ b/config/instances.yaml
@@ -6,6 +6,7 @@ virtualmachines:
     memory: "4G"
     cores: 1
     image_size: "40G"
+    register_satellite: false
     packages:
       - stress-ng
     tags:

--- a/setup-automation/setup-rhel.sh
+++ b/setup-automation/setup-rhel.sh
@@ -2,6 +2,10 @@
 
 # create notes file and populate with some text
 
+# Unregister and register the VM
+subscription-manager clean
+subscription-manager register --activationkey=12-5-22-instruqt --org=12451665 --force
+
 touch /root/quote.txt
 echo "Just thinking about everything I have been through, and how huge it all feels." >> /root/quote.txt
 echo "The fact that it is just a small part of something larger" >> /root/quote.txt


### PR DESCRIPTION
## Summary
- Updated `instances.yaml` image to `rhel-10-2-eus-06-08-26`
- Disabled satellite registration (`register_satellite: false`)
- Commented out packages block
- Added subscription-manager clean & re-register to `setup-rhel.sh`
- Part of RHEL 10.2 lab migration

## Lab
helpful-commands